### PR TITLE
Action the comments from user in support forum ( free features )

### DIFF
--- a/admin/comment_form_admin.php
+++ b/admin/comment_form_admin.php
@@ -184,8 +184,9 @@ class Comment_Form_Admin extends Comment_Form_Main {
 	 */
     public function sanitize_settings ( $data ){
 
-    	$data['text_before'] = wp_kses_post( $data['text_before'] );
-    	$data['text_after']  = wp_kses_post( $data['text_after'] );
+    	$data['text_before']  = wp_kses_post( $data['text_before'] );
+    	$data['text_after']   = wp_kses_post( $data['text_after'] );
+        $data['cookies_text'] = wp_kses_post( $data['cookies_text'] );
 
     	return $data;
 	}

--- a/admin/views/fields.php
+++ b/admin/views/fields.php
@@ -30,6 +30,14 @@ class Comment_Form_Admin_Fields extends Comment_Form_Main {
             'comment-form-fields',
             'comment_form_fields_section'
         );
+
+        add_settings_field(
+            'commentform_settings_remove_cookies',
+            __('Remove consent field', 'commentform'),
+            array($this, 'render_remove_cookies_field_callback'),
+            'comment-form-fields',
+            'comment_form_fields_section'
+        );
     }
     
     /**
@@ -103,6 +111,34 @@ class Comment_Form_Admin_Fields extends Comment_Form_Main {
             );
         ?>
         <p><?php _e('Removes the "email" field with css. Use this only if the method above doesn’t work. This uses "display:none" on the most common css selectors for the email field. The value might still get submitted by bots and tech-savvy users.', 'commentform') ?></p>
+    <?php }
+
+    /**
+     * consent field settings
+     *
+     * @since 1.2.0
+     */
+    public function render_remove_cookies_field_callback() { ?>
+        <?php
+            $this->generate_checkbox(
+                'commentform_settings[remove_cookies]',
+                '1',
+                checked(1, $this->options('remove_cookies'), false),
+                false,
+                'Remove consent field'
+            );
+        ?>
+        <p><?php _e('Removes the "consent" field from the frontend programmatically.', 'commentform') ?></p>
+        <?php
+            $this->generate_checkbox(
+                'commentform_settings[remove_cookies_css]',
+                '1',
+                checked(1, $this->options('remove_cookies_css'), false),
+                false,
+                'Remove consent field with css'
+            );
+        ?>
+        <p><?php _e('Removes the "consent" field with css. Use this only if the method above doesn’t work. This uses "display:none" on the most common css selectors for the consent field. The value might still get submitted by bots and tech-savvy users.', 'commentform') ?></p>
     <?php }
 }
 

--- a/admin/views/text.php
+++ b/admin/views/text.php
@@ -30,6 +30,14 @@ class Comment_Form_Admin_Text extends Comment_Form_Main {
             'comment-form-text',
             'comment_form_texts_section'
         );
+
+        add_settings_field(
+            'commentform_settings_consent_text',
+            __('Texts for consent', 'commentform'),
+            array($this, 'render_comment_consent_text_callback'),
+            'comment-form-text',
+            'comment_form_texts_section'
+        );
     }
 
     /**
@@ -95,6 +103,28 @@ class Comment_Form_Admin_Text extends Comment_Form_Main {
 
         <textarea rows="5" name="commentform_settings[text_after]" class="mt-4"><?php $this->options('text_after') ?></textarea>
         <p><?php _e('This text is inserted after the form when commenting if commiting is allowed to the user.', 'commentform') ?></p>
+    <?php }
+
+    /**
+     * Change consent text
+     *
+     * @since 1.0.0
+     */
+    public function render_comment_consent_text_callback() { ?>
+        <?php 
+            $this->generate_checkbox(
+                'commentform_settings[cookies_consent]',
+                '1',
+                checked(1, $this->options('cookies_consent'), false),
+                false,
+                'Remove consent default text'
+            ); 
+        ?>
+        <p><?php _e('This is currently:', 'commentform') ?></p>
+        <p><?php _e( 'Save my name, email, and website in this browser for the next time I comment.' ) ?></p>
+        
+        <textarea rows="5" name="commentform_settings[cookies_text]"><?php $this->options('cookies_text') ?></textarea>
+        <p><?php _e('If the consent field is enabled, this text will appear beside it.', 'commentform') ?></p>
     <?php }
 }
 

--- a/frontend/comment_form_frontend.php
+++ b/frontend/comment_form_frontend.php
@@ -15,6 +15,8 @@ class Comment_Form_Frontend extends Comment_Form_Main {
         add_filter('comment_form_defaults', array($this, 'comment_form_defaults_filter'));
         // comment form do before printing the form
         add_action('comment_form_top', array($this, 'comment_form_top_action'));
+        // comment form do at the bottom of the comment form, inside the closing form tag
+        add_action('comment_form_after_fields', array($this, 'comment_form_cookies_action'));
         // comment form do after fields where rendered
         add_action('comment_form_after_fields', array($this, 'comment_form_after_fields_action'));
         // manipulate the comment form markup on its output
@@ -49,6 +51,11 @@ class Comment_Form_Frontend extends Comment_Form_Main {
             unset($fields['url']);
         }
 
+        // remove the consent field
+        if ($options['remove_cookies'] && isset($fields['cookies'])) {
+            unset($fields['cookies']);
+        }
+
         return $fields;
     }
 
@@ -70,6 +77,11 @@ class Comment_Form_Frontend extends Comment_Form_Main {
         // hide the default text after the form
         if ($options['hide_notes_after']) {
             $defaults['comment_notes_after'] = '';
+        }
+
+        // hide the default text after the form
+        if ($options['cookies_consent']) {
+            $defaults['cookies'] = '';
         }
         return $defaults;
     }
@@ -93,6 +105,27 @@ class Comment_Form_Frontend extends Comment_Form_Main {
             echo '<div class="comment-form-left">';
         }
     }
+
+    /**
+     * action to set comment cookies
+     *
+     * @since 1.0.0
+     */
+    public function comment_form_cookies_action() {
+        $options = $this->options();
+    
+        // Print custom consent text.
+        if (isset($options['cookies_text']) && $options['cookies_text'] !== '') {
+            echo "<script>
+                document.addEventListener('DOMContentLoaded', function() {
+                    var consentLabel = document.querySelector('.comment-form-cookies-consent label');
+                    if (consentLabel) {
+                        consentLabel.textContent = " . json_encode($options['cookies_text']) . ";
+                    }
+                });
+            </script>";
+        }
+    }    
 
     /**
      * action to trigger after the fields (username, email, url) where displayed
@@ -164,6 +197,11 @@ class Comment_Form_Frontend extends Comment_Form_Main {
         // .comment-form-email as in the default comment form in /wp-includes/comment-template.php
         if ($options['remove_email_css']) {
             echo "<style>.comment-form-email, #email {display:none;}</style>";
+        }
+        // css code to hide the consent field
+        // .comment-form-cookies-consent as in the default comment form in /wp-includes/comment-template.php
+        if ($options['remove_cookies_css']) {
+            echo "<style>.comment-form > p.comment-form-cookies-consent {display:none;}</style>";
         }
         // apply styles for two columns comment form layout
         if ($options['two_columns'] && !is_user_logged_in()) {

--- a/inc/comment_form_main.php
+++ b/inc/comment_form_main.php
@@ -117,12 +117,16 @@ class Comment_Form_Main {
         $defaults = array(
             'hide_notes_after' => 0,
             'hide_notes_before' => 0,
+            'cookies_consent' => 0,
             'remove_email' => false,
             'remove_email_css' => false,
             'hide_url' => 0,
             'hide_url_css' => false,
+            'remove_cookies' => false,
+            'remove_cookies_css' => false,
             'text_after' => '',
             'text_before' => '',
+            'cookies_text' => '',
             'two_columns' => false
         );
 


### PR DESCRIPTION
## Ticket
https://trello.com/c/glfI3glk/425-sc-action-the-comments-from-user-in-support-forum-can-all-be-free-features

## Changes Made

- Added a toggle to show and hide the consent field, and the ability to modify its text.


## Steps to Test
1. Checkout this branch
2. On project root, run `npm install` to install js and php dependencies
3. Run `npm run build`
